### PR TITLE
Removed unrequired `eval -o json` arguments from yq

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -57,7 +57,7 @@ function json_to_yaml() {
 
 function extend() {
   local extend="$1"
-  jq --argjson extend "$(yq eval -o json <<<"$extend")" '
+  jq --argjson extend "$(yq <<<"$extend")" '
     def types($vals):
       .
       | $vals
@@ -106,7 +106,7 @@ function overlay() {
 
 function convert() {
   local res
-  res="$(yq eval -o json)"
+  res="$(yq)"
 
   local -a imports
   mapfile -t imports < <(jq -cr '."\\{import}" // [] | .[]' <<<"$res")


### PR DESCRIPTION
The `eval -o json` arguments passed to `yq` cause the underlying `jq` command to fail in `build.sh`:

```
jq: Unknown option -o
Use jq --help for help with command-line options
```

I'm not sure if it's been removed recently, but `yq` seems to export output in JSON format anyway if no output is specified - therefore running `yq` with no options seems to work just fine in my case.